### PR TITLE
_set does not explicitly check equality for arrays/objects

### DIFF
--- a/src/mixins/assettable.js
+++ b/src/mixins/assettable.js
@@ -11,11 +11,9 @@ define([
         return true;
     }
     
-    
+    // won't work while comparing array of arrays (multidimensional), can be implemented with some recursion
     function areNotEquivArrays(newValue,oldValue) {
-        var areArraysEqual = false,
-            ltr = true,
-            rtl = true;
+        var areArraysEqual = false;
         
         //if {newValue,oldValue} are falsy or not an array this comparison is useless
         if(!newValue || 
@@ -32,30 +30,15 @@ define([
             return false;
         }
 
-        _.each(newValue,function(newVal, idx) {
-            ltr = _.isEqual(newVal, oldValue[idx]);
-            // at the first not equal break both loops, there is atleast one element
+        $.each(newValue,function(idx, newVal) {
+            areArraysEqual = _.isEqual(newVal, oldValue[idx]);
+            // at the first `not equal` break loop, there is atleast one element
             // in newValue that does not equal another in oldValue
-            if(!ltr) { 
+            if(!areArraysEqual) { 
                 return false;
             }
         });
         
-        // there is atleast one inequal value, implies arrays are not equal
-        if(!ltr) {
-            return true;
-        }
-        
-        _.each(oldValue,function(oldVal, idx){
-            rtl = _.isEqual(oldVal, newValue[idx]);
-            // at the first not equal break both loops, there is atleast one element
-            // in oldValue that does not equal another in newValue
-            if(!rtl) {
-                return false;
-            }
-        });
-        
-        areArraysEqual = ltr && rtl;
         
         return !areArraysEqual;
     }

--- a/src/mixins/assettable.js
+++ b/src/mixins/assettable.js
@@ -2,46 +2,7 @@ define([
     'vendor/jquery',
     'vendor/underscore'
 ], function($, _) {
-    var isObject = _.isObject, $isPlainObject = $.isPlainObject;
-
-    function areNotEquivDates(v1, v2) {
-        if (v1 && v1.getDate && v2 && v2.getDate) {
-            return v1.toString() !== v2.toString();
-        }
-        return true;
-    }
-    
-    // won't work while comparing array of arrays (multidimensional), can be implemented with some recursion
-    function areNotEquivArrays(newValue,oldValue) {
-        var areArraysEqual = false;
-        
-        //if {newValue,oldValue} are falsy or not an array this comparison is useless
-        if(!newValue || 
-           !$.isArray(newValue) ||
-           !oldValue ||
-           !$.isArray(oldValue) ||
-           newValue.length !== oldValue.length) {
-            return true;
-        }
-        
-        // empty arrays are equal and the previous test ensures we are indeed comparing
-        // arrays
-        if(_.isEmpty(newValue) && _.isEmpty(oldValue)) {
-            return false;
-        }
-
-        $.each(newValue,function(idx, newVal) {
-            areArraysEqual = _.isEqual(newVal, oldValue[idx]);
-            // at the first `not equal` break loop, there is atleast one element
-            // in newValue that does not equal another in oldValue
-            if(!areArraysEqual) { 
-                return false;
-            }
-        });
-        
-        
-        return !areArraysEqual;
-    }
+    var isObject = _.isObject, $isPlainObject = $.isPlainObject, isEqual = _.isEqual;
 
     // if you're trying to operate on some nested prop like `foo.bar.baz`, and
     // you've got an object `{foo: {bar: {baz: 123}}}`, then this will return
@@ -207,7 +168,8 @@ define([
             eventName = _settable.eventName,
             onChange = _settable.onChange,
             onError = _settable.onError,
-            areEqual = _settable.areEqual,
+            // default areEqual to _.isEqual if not overridden
+            areEqual = _settable.areEqual || isEqual,
             isString = _.isString,
             isPlainObject = _settable.isPlainObject,
             handleChanges = function(changes, opts) {
@@ -372,11 +334,7 @@ define([
                     value = this.get(prop);
                     newValue = newProps[prop];
 
-                    valuesArentEqual = areEqual?
-                        !areEqual(value, newValue) :
-                        newValue !== value && areNotEquivDates(value, newValue) && 
-                                     areNotEquivArrays(value, newValue) &&
-                                     !_.isEqual(value, newValue);
+                    valuesArentEqual = !areEqual(value, newValue);
 
                     if (valuesArentEqual ||
 
@@ -426,6 +384,5 @@ define([
 
     asSettable.nested = nested;
     asSettable.flattened = flattened;
-    asSettable.areNotEquivArrays = areNotEquivArrays;
     return asSettable;
 });

--- a/src/mixins/assettable.js
+++ b/src/mixins/assettable.js
@@ -13,8 +13,8 @@ define([
     
     
     function areNotEquivArrays(newValue,oldValue) {
-        return true;
-        var ltr = true,
+        var areArraysEqual = false,
+            ltr = true,
             rtl = true;
         
         //if {newValue,oldValue} are falsy or not an array this comparison is useless
@@ -26,22 +26,17 @@ define([
             return true;
         }
         
-        // empty arrays are very much equal and the previous test ensures we are indeed comparing
+        // empty arrays are equal and the previous test ensures we are indeed comparing
         // arrays
         if(_.isEmpty(newValue) && _.isEmpty(oldValue)) {
             return false;
         }
 
-        _.each(newValue,function(newVal) {
-            _.each(oldValue,function(oldVal){
-                ltr = ltr && _.isEqual(newVal, oldVal);
-                // at the first not equal break both loops, there is atleast one element
-                // in newValue that does not equal another in oldValue
-                if(!ltr) { 
-                    return false;
-                }
-            });
-            if(!ltr) {
+        _.each(newValue,function(newVal, idx) {
+            ltr = _.isEqual(newVal, oldValue[idx]);
+            // at the first not equal break both loops, there is atleast one element
+            // in newValue that does not equal another in oldValue
+            if(!ltr) { 
                 return false;
             }
         });
@@ -51,21 +46,18 @@ define([
             return true;
         }
         
-        _.each(oldValue,function(oldVal){
-            _.each(newValue,function(newVal){
-                rtl = _.isEqual(oldVal, newVal);
-                // at the first not equal break both loops, there is atleast one element
-                // in oldValue that does not equal another in newValue
-                if(!rtl) {
-                    return false;
-                }
-            });
+        _.each(oldValue,function(oldVal, idx){
+            rtl = _.isEqual(oldVal, newValue[idx]);
+            // at the first not equal break both loops, there is atleast one element
+            // in oldValue that does not equal another in newValue
             if(!rtl) {
                 return false;
             }
         });
         
-        return (ltr || rtl);
+        areArraysEqual = ltr && rtl;
+        
+        return !areArraysEqual;
     }
 
     // if you're trying to operate on some nested prop like `foo.bar.baz`, and
@@ -451,6 +443,6 @@ define([
 
     asSettable.nested = nested;
     asSettable.flattened = flattened;
-
+    asSettable.areNotEquivArrays = areNotEquivArrays;
     return asSettable;
 });

--- a/src/mixins/assettable.js
+++ b/src/mixins/assettable.js
@@ -10,6 +10,63 @@ define([
         }
         return true;
     }
+    
+    
+    function areNotEquivArrays(newValue,oldValue) {
+        return true;
+        var ltr = true,
+            rtl = true;
+        
+        //if {newValue,oldValue} are falsy or not an array this comparison is useless
+        if(!newValue || 
+           !$.isArray(newValue) ||
+           !oldValue ||
+           !$.isArray(oldValue) ||
+           newValue.length !== oldValue.length) {
+            return true;
+        }
+        
+        // empty arrays are very much equal and the previous test ensures we are indeed comparing
+        // arrays
+        if(_.isEmpty(newValue) && _.isEmpty(oldValue)) {
+            return false;
+        }
+
+        _.each(newValue,function(newVal) {
+            _.each(oldValue,function(oldVal){
+                ltr = ltr && _.isEqual(newVal, oldVal);
+                // at the first not equal break both loops, there is atleast one element
+                // in newValue that does not equal another in oldValue
+                if(!ltr) { 
+                    return false;
+                }
+            });
+            if(!ltr) {
+                return false;
+            }
+        });
+        
+        // there is atleast one inequal value, implies arrays are not equal
+        if(!ltr) {
+            return true;
+        }
+        
+        _.each(oldValue,function(oldVal){
+            _.each(newValue,function(newVal){
+                rtl = _.isEqual(oldVal, newVal);
+                // at the first not equal break both loops, there is atleast one element
+                // in oldValue that does not equal another in newValue
+                if(!rtl) {
+                    return false;
+                }
+            });
+            if(!rtl) {
+                return false;
+            }
+        });
+        
+        return (ltr || rtl);
+    }
 
     // if you're trying to operate on some nested prop like `foo.bar.baz`, and
     // you've got an object `{foo: {bar: {baz: 123}}}`, then this will return
@@ -342,7 +399,9 @@ define([
 
                     valuesArentEqual = areEqual?
                         !areEqual(value, newValue) :
-                        newValue !== value && areNotEquivDates(value, newValue);
+                        newValue !== value && areNotEquivDates(value, newValue) && 
+                                     areNotEquivArrays(value, newValue) &&
+                                     !_.isEqual(value, newValue);
 
                     if (valuesArentEqual ||
 

--- a/src/mixins/assettable/test.js
+++ b/src/mixins/assettable/test.js
@@ -691,6 +691,145 @@ define([
         ok(changeFired);
         ok(!errorFired);
     });
+    
+    test('setting the same string on a property should not trigger a change',function(){
+        var changeFired = false,
+            BaseClass = Class.extend({
+                onChange: function(changes, opts) {
+                    changeFired = true;
+                }
+            }),
+            instance;
+            
+        asSettable.call(BaseClass.prototype, {
+            onChange: 'onChange'
+        });
+        
+        instance = BaseClass();
+        instance.set('stringProp',"winterfell");
+        ok(changeFired,'setting value initially triggers change');
+        changeFired = false;
+        instance.set('stringProp','stark');
+        equal(changeFired, true,'setting a different value triggers change');
+        changeFired = false;
+        instance.set('stringProp','stark');
+        equal(changeFired, false,'setting same value again should not trigger a change');
+    });
+    
+    test('setting the same array on a property should not trigger a change',function(){
+        var changeFired = false,
+            BaseClass = Class.extend({
+                onChange: function(changes, opts) {
+                    changeFired = true;
+                }
+            }),
+            instance;
+            
+        asSettable.call(BaseClass.prototype, {
+            onChange: 'onChange'
+        });
+        
+        instance = BaseClass();
+        instance.set('arrayProp',[1,2,3,4]);
+        ok(changeFired,'setting value initially triggers change');
+        changeFired = false;
+        instance.set('arrayProp',[1,2,3]);
+        equal(changeFired, true,'setting a different value triggers change');
+        changeFired = false;
+        instance.set('arrayProp',[1,2,3]);
+        equal(changeFired, false,'setting same value again should not trigger a change');
+    });
+    
+    test('setting the same object on a property should not trigger a change',function(){
+        var changeFired = false,
+            BaseClass = Class.extend({
+                onChange: function(changes, opts) {
+                    changeFired = true;
+                }
+            }),
+            instance;
+            
+        asSettable.call(BaseClass.prototype, {
+            onChange: 'onChange'
+        });
+        
+        //TODO using notNested might not be a solution, need more info on what is expected
+        instance = BaseClass();
+        instance.set('objProp',{"a":1,"b":2,"c":3},{notNested:true});
+        ok(changeFired,'setting value initially triggers change');
+        changeFired = false;
+        instance.set('objProp',{"a":1,"b":2},{notNested:true});
+        equal(changeFired, true,'setting a different value triggers change');
+        changeFired = false;
+        instance.set('objProp',{"a":1,"b":2},{notNested:true});
+        equal(changeFired, false,'setting same value again should not trigger a change');
+        
+        console.log(instance.get('objProp'))
+    });
+    
+    module('Utility function areNotEquivArrays') 
+    
+    var areNotEquivArrays = function (newValue,oldValue) {
+        var ltr = true,
+            rtl = true;
+        
+        //if {newValue,oldValue} are falsy or not an array this comparison is useless
+        if(!newValue || 
+           !$.isArray(newValue) ||
+           !oldValue ||
+           !$.isArray(oldValue) ||
+           newValue.length !== oldValue.length) {
+            return true;
+        }
+        
+        // empty arrays are very much equal and the previous test ensures we are indeed comparing
+        // arrays
+        if(_.isEmpty(newValue) && _.isEmpty(oldValue)) {
+            return false;
+        }
+
+        _.each(newValue,function(newVal) {
+            _.each(oldValue,function(oldVal){
+                ltr = ltr && _.isEqual(newVal, oldVal);
+                // at the first not equal break both loops, there is atleast one element
+                // in newValue that does not equal another in oldValue
+                if(!ltr) { 
+                    return false;
+                }
+            });
+            if(!ltr) {
+                return false;
+            }
+        });
+        
+        // there is atleast one inequal value, implies arrays are not equal
+        if(!ltr) {
+            return true;
+        }
+        
+        _.each(oldValue,function(oldVal){
+            _.each(newValue,function(newVal){
+                rtl = _.isEqual(oldVal, newVal);
+                // at the first not equal break both loops, there is atleast one element
+                // in oldValue that does not equal another in newValue
+                if(!rtl) {
+                    return false;
+                }
+            });
+            if(!rtl) {
+                return false;
+            }
+        });
+        
+        return (ltr || rtl);
+    }
+    
+    test("basic tests", function(){
+        //equal(areNotEquivArrays([],[]), false, 'empty arrays are equal');
+        ok(areNotEquivArrays([1,2],[]), 'Compare empty array with non-empty ones'); 
+    }); 
+    
+
 
     start();
 });

--- a/src/mixins/assettable/test.js
+++ b/src/mixins/assettable/test.js
@@ -769,64 +769,13 @@ define([
     
     module('Utility function areNotEquivArrays') 
     
-    var areNotEquivArrays = function (newValue,oldValue) {
-        var ltr = true,
-            rtl = true;
-        
-        //if {newValue,oldValue} are falsy or not an array this comparison is useless
-        if(!newValue || 
-           !$.isArray(newValue) ||
-           !oldValue ||
-           !$.isArray(oldValue) ||
-           newValue.length !== oldValue.length) {
-            return true;
-        }
-        
-        // empty arrays are very much equal and the previous test ensures we are indeed comparing
-        // arrays
-        if(_.isEmpty(newValue) && _.isEmpty(oldValue)) {
-            return false;
-        }
-
-        _.each(newValue,function(newVal) {
-            _.each(oldValue,function(oldVal){
-                ltr = ltr && _.isEqual(newVal, oldVal);
-                // at the first not equal break both loops, there is atleast one element
-                // in newValue that does not equal another in oldValue
-                if(!ltr) { 
-                    return false;
-                }
-            });
-            if(!ltr) {
-                return false;
-            }
-        });
-        
-        // there is atleast one inequal value, implies arrays are not equal
-        if(!ltr) {
-            return true;
-        }
-        
-        _.each(oldValue,function(oldVal){
-            _.each(newValue,function(newVal){
-                rtl = _.isEqual(oldVal, newVal);
-                // at the first not equal break both loops, there is atleast one element
-                // in oldValue that does not equal another in newValue
-                if(!rtl) {
-                    return false;
-                }
-            });
-            if(!rtl) {
-                return false;
-            }
-        });
-        
-        return (ltr || rtl);
-    }
+    var areNotEquivArrays = asSettable.areNotEquivArrays
     
     test("basic tests", function(){
-        //equal(areNotEquivArrays([],[]), false, 'empty arrays are equal');
+        equal(areNotEquivArrays([],[]), false, 'empty arrays are equal');
         ok(areNotEquivArrays([1,2],[]), 'Compare empty array with non-empty ones'); 
+        equal(areNotEquivArrays([{a:1,b:2},{a:1,b:2,c:3}],
+        [{a:1,b:2},{a:1,b:2,c:3}]),false, 'Compare empty array with non-empty ones'); 
     }); 
     
 

--- a/src/mixins/assettable/test.js
+++ b/src/mixins/assettable/test.js
@@ -763,8 +763,7 @@ define([
         changeFired = false;
         instance.set('objProp',{"a":1,"b":2},{notNested:true});
         equal(changeFired, false,'setting same value again should not trigger a change');
-        
-        console.log(instance.get('objProp'))
+
     });
     
     module('Utility function areNotEquivArrays') 
@@ -773,10 +772,29 @@ define([
     
     test("basic tests", function(){
         equal(areNotEquivArrays([],[]), false, 'empty arrays are equal');
-        ok(areNotEquivArrays([1,2],[]), 'Compare empty array with non-empty ones'); 
+        ok(areNotEquivArrays([1,2],[]), 'compare empty array with a non-empty one'); 
+        
+        ok(areNotEquivArrays([1,2],[1,2,19]), 'arrays with different lengths are not equal'); 
+        ok(areNotEquivArrays([1,2,3,4],[1,3,2,4]), 'order is important');
+        
+        equal(areNotEquivArrays([2,8,10,-1,32], [2,8,10,-1,32]), false, 'compare regular arrays- equal'); 
+        equal(areNotEquivArrays([2,8,30,-1,32], [2,8,18,-1,32]), true, 'compare regular arrays - not equal'); 
+        
         equal(areNotEquivArrays([{a:1,b:2},{a:1,b:2,c:3}],
-        [{a:1,b:2},{a:1,b:2,c:3}]),false, 'Compare empty array with non-empty ones'); 
+            [{a:1,b:2},{a:1,b:2,c:3}]), false, 'compare array of objects - equal'); 
+        equal(areNotEquivArrays([{a:1,b:2},{a:1,b:2,c:3}],
+            [{a:1,b:2},{b:2,c:3}]), true, 'compare array of objects - not equal'); 
+            
+        equal(areNotEquivArrays([new Date(2013,10,10), new Date(2013,11,10)],[new Date(2013,10,10), new Date(2013,11,10)]),
+            false, 'compare array of dates - equal');
+        equal(areNotEquivArrays([new Date(2013,10,10), new Date(2013,11,10)],[new Date(2013,12,12), new Date(2013,11,10)]),
+            true, 'compare array of dates - not equal');
+        
+            
+        
     }); 
+    
+    
     
 
 

--- a/src/mixins/assettable/test.js
+++ b/src/mixins/assettable/test.js
@@ -765,38 +765,6 @@ define([
         equal(changeFired, false,'setting same value again should not trigger a change');
 
     });
-    
-    module('Utility function areNotEquivArrays') 
-    
-    var areNotEquivArrays = asSettable.areNotEquivArrays
-    
-    test("basic tests", function(){
-        equal(areNotEquivArrays([],[]), false, 'empty arrays are equal');
-        ok(areNotEquivArrays([1,2],[]), 'compare empty array with a non-empty one'); 
-        
-        ok(areNotEquivArrays([1,2],[1,2,19]), 'arrays with different lengths are not equal'); 
-        ok(areNotEquivArrays([1,2,3,4],[1,3,2,4]), 'order is important');
-        
-        equal(areNotEquivArrays([2,8,10,-1,32], [2,8,10,-1,32]), false, 'compare regular arrays- equal'); 
-        equal(areNotEquivArrays([2,8,30,-1,32], [2,8,18,-1,32]), true, 'compare regular arrays - not equal'); 
-        
-        equal(areNotEquivArrays([{a:1,b:2},{a:1,b:2,c:3}],
-            [{a:1,b:2},{a:1,b:2,c:3}]), false, 'compare array of objects - equal'); 
-        equal(areNotEquivArrays([{a:1,b:2},{a:1,b:2,c:3}],
-            [{a:1,b:2},{b:2,c:3}]), true, 'compare array of objects - not equal'); 
-            
-        equal(areNotEquivArrays([new Date(2013,10,10), new Date(2013,11,10)],[new Date(2013,10,10), new Date(2013,11,10)]),
-            false, 'compare array of dates - equal');
-        equal(areNotEquivArrays([new Date(2013,10,10), new Date(2013,11,10)],[new Date(2013,12,12), new Date(2013,11,10)]),
-            true, 'compare array of dates - not equal');
-        
-            
-        
-    }); 
-    
-    
-    
-
 
     start();
 });


### PR DESCRIPTION
_set checks equality for date values and primitives, but not in the case of array/object parameters.  I have used the function areNotEquivArrays for verifying array equality (even in the case of array of objects as this is the case with models) and _.isEqual for objects.
I have also added some test cases to verify this scenario for strings/arrays/objects.
